### PR TITLE
Class not found: wrong package

### DIFF
--- a/src/main/java/com/hp/autonomy/idolutils/processors/AciResponseJaxbProcessorFactory.java
+++ b/src/main/java/com/hp/autonomy/idolutils/processors/AciResponseJaxbProcessorFactory.java
@@ -8,7 +8,7 @@ package com.hp.autonomy.idolutils.processors;
 import com.autonomy.aci.client.services.Processor;
 import com.hp.autonomy.idolutils.IdolXmlMarshaller;
 import com.hp.autonomy.idolutils.IdolXmlMarshallerImpl;
-import com.hp.autonomy.types.idol.QueryResponse;
+import com.hp.autonomy.types.idol.responses.QueryResponse;
 
 @SuppressWarnings("WeakerAccess")
 public class AciResponseJaxbProcessorFactory {


### PR DESCRIPTION
Class imports `com.hp.autonomy.types.idol.QueryRespons` which doesn't exist in com.hp.autonomy.types.idol in `master`. This breaks compilation after package version update.
Compare with: https://github.com/hpe-idol/java-idol-types/blob/master/src/main/java/com/hp/autonomy/types/idol/responses/QueryResponse.java where should be required class.